### PR TITLE
remove deprecated function and change non-working code

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
 pandas==0.23.4
 pandas-datareader==0.7.0
 boto3==1.9.25
-fix-yahoo-finance==0.0.22
+yfinance==0.1.59

--- a/src/simulator.py
+++ b/src/simulator.py
@@ -37,7 +37,7 @@ import numpy as np
 import datetime, time
 from math import sqrt
 # from scipy.stats import norm
-import fix_yahoo_finance as yf
+import yfinance as yf
 import boto3
 import uuid
 import subprocess
@@ -190,9 +190,10 @@ def run_simulations(parser):
     df2 = pd.DataFrame(portfolio_total, columns=["portfolioTotal"])
 
     # Create one data frame and write to file.
-    result = pd.concat([df1, df2], axis=1, join_axes=[df1.index])
+    df3 = pd.concat([df1, df2], axis=1)
+    df3 = df3.reindex(df1.index)
     joined_result_file = file_prepend_str + "_" + STOCK + "_" + (str(uuid.uuid4()))[:6] + "_MonteCarloSimResult.csv"
-    result.to_csv(joined_result_file)
+    df3.to_csv(joined_result_file)
     saveToS3(s3_bucket, joined_result_file, STOCK)
 
 


### PR DESCRIPTION
1. about fix_yahoo_finance
it returns "ValueError: No objects to concatenate" error.
so I changed it to using yfinance.
and it works fine.

2. about result = pd.concat([df1, df2], axis=1, join_axes=[df1.index])
'join_axes' was deprecated in version 0.25
so change it to be below
df3 = pd.concat([df1, df2], axis=1)
df3 = df3.reindex(df1.index)

